### PR TITLE
removed build tools during production (heroic)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm start
+web: npm run production

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node server/server.js",
     "start-dev": "npm run task",
     "task": "gulp",
-    "postinstall": "bower install"
+    "postinstall": "bower install",
+    "production": "node server/server.js"
   },
   "dependencies": {
     "async": "^1.5.2",
@@ -33,5 +34,8 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
+  },
+  "devDependencies": {
+    "morgan": "^1.7.0"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -7,8 +7,13 @@ var controller = require('./../Controller/controler.js');
 var mongoURI = 'mongodb://lkee:' + process.env.stuff3 + '@ds011439.mlab.com:11439/heroku_wk47xfd5';
 mongoose.connect(mongoURI);
 
+// morgan for server loggin outside of heroku
+if (!process.env.PORT) {
+  app.use(require('morgan')('dev'))
+}
+
 app.set('port', (process.env.PORT || 5000));
-app.use(bodyParser.urlencoded());
+app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.json());
 
 app.use(express.static(path.join(__dirname, './..')));


### PR DESCRIPTION
Tested it as far as I could without using the config files. Should help with your server issues.

Package.json:
added a production script which avoids running the
gulp-file. I’m thinking this is why your server is occasionally unable
to send out bundle.js

Procfile:
Changed so that web start boots the production script instead of npm
start (consisting of gulp => browserify, nodemon, watchify). Fairly
certain nodemon and/or browserify was the root of the issue.

server:
* modified body-parser middleware to remove server’s ‘deprecated’
warning.
* added morgan in development environment for server-logging to view
incoming requests.